### PR TITLE
Change one_time to once

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,5 +2,5 @@ class Task < ApplicationRecord
   validates_presence_of :name, :category, :time_needed, :user_id
 
   enum category: { rest: 0, hobby: 1, chore: 2 }
-  enum frequency: { one_time: 0, daily: 1, weekly: 2, monthly: 3, annual: 4 }
+  enum frequency: { once: 0, daily: 1, weekly: 2, monthly: 3, annual: 4 }
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -22,8 +22,8 @@ FactoryBot.define do
       category { "chore" }
     end
     
-    trait :one_time do
-      frequency { "one_time" }
+    trait :once do
+      frequency { "once" }
     end
     
     trait :daily do

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -10,6 +10,6 @@ RSpec.describe Task, type: :model do
 
   describe "Enum Definitions" do
     it { should define_enum_for(:category).with_values([:rest, :hobby, :chore]) }
-    it { should define_enum_for(:frequency).with_values([:one_time, :daily, :weekly, :monthly, :annual]) }
+    it { should define_enum_for(:frequency).with_values([:once, :daily, :weekly, :monthly, :annual]) }
   end
 end

--- a/spec/requests/api/v1/tasks_request_spec.rb
+++ b/spec/requests/api/v1/tasks_request_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe "Tasks API" do
       expect(created_task.name).to eq(task_params[:name])
       expect(created_task.category).to eq(task_params[:category])
       expect(created_task.time_needed).to eq(task_params[:time_needed])
-      expect(created_task.frequency).to eq("one_time")
+      expect(created_task.frequency).to eq("once")
     end
 
     it "does not create a new task and returns status code 400 if invalid params passed" do


### PR DESCRIPTION
# Describe the changes below:
Change every occurance of enum role `one_time` to `once` for a cleaner display on front end

# Relevant feature:
features relating to tasks

# Before submitting, check the following:
- [x] Entire test suite is passing
- [100%] SimpleCov test percentage