### PR TITLE
Add line in strong params to swap :image to :image_url

### DIFF
--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -45,6 +45,7 @@ class Api::V1::TasksController < ApplicationController
 
   private
   def task_params
-    params.permit(:name, :category, :mandatory, :event_date, :frequency, :time_needed, :user_id, :notes, :image)
+    params[:image_url] = params[:image]
+    params.permit(:name, :category, :mandatory, :event_date, :frequency, :time_needed, :user_id, :notes, :image_url)
   end
 end


### PR DESCRIPTION
# Describe the changes below:
In Tasks controller, 
add the line `params[:image_url] = params[:image]` in strong params method to create the :image_url attribute from params as given by FE

Permit the attribute :image_url