### PR TITLE
Change params to accept image_url from FE

### DIFF
--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::TasksController < ApplicationController
   def create
-    task =  Task.new(name: params[:name], mandatory: params[:mandatory], category: params[:category], image_url: params[:image], user_id: params[:user_id], event_date: params[:event_date], frequency: params[:frequency], notes: params[:notes])
-    task.save!  
+    task =  Task.new(task_params)
+    task.save!
     render json: { message: "'#{Task.last.name}' added!" }, status: 201
   end
 
@@ -45,7 +45,6 @@ class Api::V1::TasksController < ApplicationController
 
   private
   def task_params
-    params[:image_url] = params[:image]
     params.permit(:name, :category, :mandatory, :event_date, :frequency, :user_id, :notes, :image_url)
   end
 end


### PR DESCRIPTION
# Describe the changes below:

BE previously took the param `:image` from Front End, then converted it to `:image_url` before saving

FE will instead be updated to send the attribute as `:image_url`